### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/Containers/Docker_notes.Rmd
+++ b/Containers/Docker_notes.Rmd
@@ -97,7 +97,7 @@ Push the image to github
 ```{bash, eval = F}
 export GHCR=My_Token
 own_image % echo "$GHCR" | docker login ghcr.io -u nimarafati --password-stdin 
-own_image % docker build -t gchr.io/nimarafati/docker_demo/spade:1.0 .
+own_image % docker build -t ghcr.io/nimarafati/docker_demo/spade:1.0 .
 ```
 
 


### PR DESCRIPTION
Hi `nimarafati/Notes`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.